### PR TITLE
Fix date config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 [frontmatter]
-date = ["lastmod", "date", ":filename"]
+date = [ ":filename", ":default" ]
+publishDate = [ ":filename", ":default" ]
 [permalinks]
 blog = "blog/:slug/"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ range .Pages }}
-<h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+<h2><a href="{{ .RelPermalink }}">{{ .Title }} {{ .PublishDate }}</a></h2>
 {{ .Summary }}
 <p><a href="{{ .RelPermalink }}">Read more</a></p>
 {{ end }}


### PR DESCRIPTION
The date of publishing is controlled by `publishDate`. This is the default:

```
publishDate = ["publishDate", "date"]
```

Note that there is no `:filename` in the above, so the publish date was not set.

Closes https://github.com/gohugoio/hugo/issues/5726